### PR TITLE
feat: use timestamp based account to call the registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "assert-json-diff"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f1c3703dd33532d7f0ca049168930e9099ecac238e23cf932f3a69c42f06da"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
@@ -606,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "5999502d32b9c48d492abe66392408144895020ec4709e549e840799f3bb74c0"
 dependencies = [
  "generic-array",
  "typenum",
@@ -769,9 +769,9 @@ dependencies = [
 
 [[package]]
 name = "diff"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "difflib"
@@ -834,9 +834,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "ena"
@@ -926,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -1763,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"
@@ -1944,18 +1944,18 @@ checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "pin-project"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2203,9 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2223,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -2519,18 +2519,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2539,9 +2539,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa",
  "ryu",
@@ -2685,9 +2685,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc88c725d61fc6c3132893370cac4a0200e3fedf5da8331c570664b1987f5ca2"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
@@ -2723,7 +2723,7 @@ dependencies = [
 [[package]]
 name = "starknet"
 version = "0.2.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs#80164b26d40e1b8f95058529399b237317bbe98a"
+source = "git+https://github.com/xJonathanLEI/starknet-rs#da4f1d2d59eaa23575278f73fb8c7c311b11af3c"
 dependencies = [
  "starknet-accounts",
  "starknet-contract",
@@ -2736,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "starknet-accounts"
 version = "0.1.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs#80164b26d40e1b8f95058529399b237317bbe98a"
+source = "git+https://github.com/xJonathanLEI/starknet-rs#da4f1d2d59eaa23575278f73fb8c7c311b11af3c"
 dependencies = [
  "async-trait",
  "starknet-core",
@@ -2748,7 +2748,7 @@ dependencies = [
 [[package]]
 name = "starknet-contract"
 version = "0.1.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs#80164b26d40e1b8f95058529399b237317bbe98a"
+source = "git+https://github.com/xJonathanLEI/starknet-rs#da4f1d2d59eaa23575278f73fb8c7c311b11af3c"
 dependencies = [
  "flate2",
  "rand",
@@ -2763,7 +2763,7 @@ dependencies = [
 [[package]]
 name = "starknet-core"
 version = "0.2.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs#80164b26d40e1b8f95058529399b237317bbe98a"
+source = "git+https://github.com/xJonathanLEI/starknet-rs#da4f1d2d59eaa23575278f73fb8c7c311b11af3c"
 dependencies = [
  "base64",
  "ethereum-types",
@@ -2780,7 +2780,7 @@ dependencies = [
 [[package]]
 name = "starknet-crypto"
 version = "0.1.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs#80164b26d40e1b8f95058529399b237317bbe98a"
+source = "git+https://github.com/xJonathanLEI/starknet-rs#da4f1d2d59eaa23575278f73fb8c7c311b11af3c"
 dependencies = [
  "crypto-bigint",
  "hex",
@@ -2798,7 +2798,7 @@ dependencies = [
 [[package]]
 name = "starknet-ff"
 version = "0.1.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs#80164b26d40e1b8f95058529399b237317bbe98a"
+source = "git+https://github.com/xJonathanLEI/starknet-rs#da4f1d2d59eaa23575278f73fb8c7c311b11af3c"
 dependencies = [
  "ark-ff",
  "bigdecimal",
@@ -2813,7 +2813,7 @@ dependencies = [
 [[package]]
 name = "starknet-macros"
 version = "0.1.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs#80164b26d40e1b8f95058529399b237317bbe98a"
+source = "git+https://github.com/xJonathanLEI/starknet-rs#da4f1d2d59eaa23575278f73fb8c7c311b11af3c"
 dependencies = [
  "starknet-core",
  "syn",
@@ -2822,7 +2822,7 @@ dependencies = [
 [[package]]
 name = "starknet-providers"
 version = "0.2.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs#80164b26d40e1b8f95058529399b237317bbe98a"
+source = "git+https://github.com/xJonathanLEI/starknet-rs#da4f1d2d59eaa23575278f73fb8c7c311b11af3c"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -2838,7 +2838,7 @@ dependencies = [
 [[package]]
 name = "starknet-signers"
 version = "0.1.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs#80164b26d40e1b8f95058529399b237317bbe98a"
+source = "git+https://github.com/xJonathanLEI/starknet-rs#da4f1d2d59eaa23575278f73fb8c7c311b11af3c"
 dependencies = [
  "async-trait",
  "starknet-core",
@@ -3137,9 +3137,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3179,13 +3179,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+checksum = "3a713421342a5a666b7577783721d3117f1b69a393df803ee17bb73b1e122a59"
 dependencies = [
  "ansi_term",
- "lazy_static",
  "matchers",
+ "once_cell",
  "regex",
  "sharded-slab",
  "smallvec",
@@ -3218,9 +3218,9 @@ dependencies = [
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
 
 [[package]]
 name = "uint"
@@ -3258,9 +3258,9 @@ checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dee68f85cab8cf68dec42158baf3a79a1cdc065a8b103025965d6ccb7f6cbd"
+checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
 dependencies = [
  "tinyvec",
 ]
@@ -3541,9 +3541,9 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"
+checksum = "20b578acffd8516a6c3f2a1bdefc1ec37e547bb4e0fb8b6b01a4cafc886b4442"
 dependencies = [
  "zeroize_derive",
 ]

--- a/src/contracts/badge_registry.rs
+++ b/src/contracts/badge_registry.rs
@@ -1,5 +1,5 @@
 use starknet::{
-    accounts::{single_owner::TransactionError, Account, Call},
+    accounts::{single_owner::TransactionError, Account, AccountCall, Call},
     core::{
         types::{BlockId, FieldElement, InvokeFunctionTransactionRequest},
         utils::get_selector_from_name,
@@ -81,9 +81,10 @@ impl BadgeRegistryClient for StarkNetClient {
         self.account
             .execute(&[Call {
                 to: self.badge_registry_address,
-                selector: get_selector_from_name("register_github_handle").unwrap(),
+                selector: get_selector_from_name("register_github_identifier").unwrap(),
                 calldata: vec![user_account_address, FieldElement::from(github_user_id)],
             }])
+            .nonce(self.get_timestamp_based_nonce())
             .send()
             .await
             .map_err(StarknetError::TransactionError)?;
@@ -98,6 +99,7 @@ mod tests {
     use crate::contracts::client::StarkNetChain;
     use crate::contracts::{self, client::StarkNetClient};
 
+    use dotenv::dotenv;
     use rocket::tokio;
     use starknet::core::types::FieldElement;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -106,7 +108,7 @@ mod tests {
         "0x65f1506b7f974a1355aeebc1314579326c84a029cd8257a91f82384a6a0ace";
 
     const BADGE_REGISTRY_ADDRESS: &str =
-        "0x0689c0f3483daffd4e79a61f22f5a093f8adee50926a96161c23b058de70200d";
+        "0x050d04dade55dbb7a7a59d8067a716d4e4b02c89a75730e1655c63a2eeafbe24";
 
     const HASH: &str = "0x287b943b1934949486006ad63ac0293038b6c818b858b09f8e0a9da12fc4074";
     const SIGNATURE_R: &str = "0xde4d49b21dd8714eaf5a1b480d8ede84d2230d1763cfe06762d8a117493bcd";
@@ -115,6 +117,7 @@ mod tests {
         "0x000049b21dd8714eaf5a1b480d8ede84d2230d1763cfe06762d8a117490000";
 
     fn new_test_client() -> StarkNetClient {
+        dotenv().ok();
         let admin_account = std::env::var("STARKNET_ACCOUNT").unwrap();
         let admin_private_key = std::env::var("STARKNET_PRIVATE_KEY").unwrap();
 

--- a/src/contracts/client.rs
+++ b/src/contracts/client.rs
@@ -1,4 +1,7 @@
-use std::str::FromStr;
+use std::{
+    str::FromStr,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use starknet::{
     accounts::SingleOwnerAccount,
@@ -48,6 +51,15 @@ impl StarkNetClient {
             account: SingleOwnerAccount::new(account_provider, signer, account_address, chain_id),
             badge_registry_address,
         }
+    }
+
+    pub fn get_timestamp_based_nonce(&self) -> FieldElement {
+        let start = SystemTime::now();
+        let timestamp = start
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards");
+
+        FieldElement::from_dec_str(&timestamp.as_micros().to_string()).unwrap()
     }
 }
 


### PR DESCRIPTION
Uses the timestamp-based accounts by providing a timestamp as nonce.

Also fix the selector.