### PR TITLE
✨ returns signup transaction hash in the Rest API

### DIFF
--- a/src/rest/mod.rs
+++ b/src/rest/mod.rs
@@ -1,4 +1,5 @@
 pub mod cors;
 pub mod health;
+pub mod problem;
 pub mod registrations;
 pub mod router;

--- a/src/rest/problem.rs
+++ b/src/rest/problem.rs
@@ -1,0 +1,32 @@
+use rocket::{
+    http::Status,
+    response::status,
+    serde::{json::Json, Serialize},
+};
+use serde_with::serde_as;
+
+// Error response following the "Problem Details for HTTP APIs" RFC: https://datatracker.ietf.org/doc/html/rfc7807
+#[serde_as]
+#[derive(Serialize, Debug, Clone)]
+#[serde(crate = "rocket::serde")]
+pub struct Problem {
+    title: String,
+    detail: String,
+    status: u16,
+}
+
+pub type ProblemResponse = status::Custom<Json<Problem>>;
+
+impl Problem {
+    pub fn new(status_code: u16, title: &str, details: String) -> Problem {
+        Problem {
+            title: title.to_string(),
+            detail: details,
+            status: status_code,
+        }
+    }
+}
+
+pub fn new_response(status: Status, title: &str, details: String) -> ProblemResponse {
+    status::Custom(status, Json(Problem::new(status.code, title, details)))
+}


### PR DESCRIPTION
Also introduces the Problem RFC to respond with errors in Rest APIs. Could be extracted into a lib later if we agree on using this (this is a standard, so IMHO we should use it).